### PR TITLE
Trino tdp integration

### DIFF
--- a/packages/okdp-packages/trinodb/README-TDP.md
+++ b/packages/okdp-packages/trinodb/README-TDP.md
@@ -1,0 +1,209 @@
+# Trino TDP Integration Guide
+
+This document outlines the steps to configure and deploy the necessary Kubernetes resources for integrating Trino with TDP, enabling support for Kerberos authentication, Hive, and HDFS query federation.
+
+## Prerequisites
+
+Ensure you have the following files available in your `../tdp-client` directory. **Note: Configuration files are auto-generated in the TDP environment.**
+
+- `trino.keytab`: Kerberos keytab for the Trino service principal.
+- `tdp_ca.crt`: The CA certificate for the TDP cluster.
+- Hadoop configuration files (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`) and `krb5.conf`.
+
+---
+
+## 1. Secrets Management
+
+Run the following commands to create the required Kubernetes secrets. These secrets store sensitive authentication materials.
+
+### Create Trino Keytab Secret
+```bash
+kubectl create secret generic trino-keytab \
+  --from-file=trino.keytab=../tdp-client/trino.keytab \
+  --namespace=default
+```
+
+### Create CA Certificate Secret
+```bash
+kubectl create secret generic tdp-ca-cert \
+  --from-file=tdp_ca.crt=../tdp-client/tdp_ca.crt \
+  --namespace=default
+```
+
+**Verification:**
+You can verify the secrets layout using `kubectl describe`:
+
+```yaml
+Name:         tdp-ca-cert
+Namespace:    default
+Type:         Opaque
+Data:
+  tdp_ca.crt: 1887 bytes
+
+Name:         trino-keytab
+Namespace:    default
+Type:         Opaque
+Data:
+  trino.keytab: 433 bytes
+```
+
+---
+
+## 2. Hadoop Client Configuration
+
+The `hadoop-client-config` ConfigMap is essential for Trino to communicate with the HDFS and Hive Metastore services. It contains the standard Hadoop XML configuration files and the Kerberos configuration, which are **auto-generated** in the TDP client directory.
+
+### Create ConfigMap
+Navigate to the directory containing your configuration files (e.g., `../tdp-client/hadoop-client`) and run:
+
+```bash
+kubectl create configmap hadoop-client-config \
+  --from-file=. \
+  --namespace=default
+```
+
+---
+
+## 3. Configuration Reference
+
+Below are examples of the **auto-generated** configurations included in the `hadoop-client-config` ConfigMap. These are provided for reference.
+
+### core-site.xml
+Defines the default filesystem, Zookeeper quorum, and proxy user settings.
+
+```xml
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://mycluster</value>
+  </property>
+  <property>
+    <name>ha.zookeeper.quorum</name>
+    <value>master-01.tdp:2181,master-02.tdp:2181,master-03.tdp:2181</value>
+  </property>
+  <property>
+    <name>ha.zookeeper.acl</name>
+    <value>sasl:nn:rwcda</value>
+  </property>
+  <property>
+    <name>hadoop.security.authentication</name>
+    <value>kerberos</value>
+  </property>
+  <property>
+    <name>hadoop.security.authorization</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>hadoop.security.auth_to_local</name>
+    <value>
+      RULE:[2:$1/$2@$0]([ndj]n/.*@REALM.TDP)s/.*/hdfs/
+      RULE:[1:$1@$0](hdfs@REALM.TDP)s/.*/hdfs/
+      RULE:[2:$1/$2@$0](trino/.*@REALM.TDP)s/.*/trino/
+      RULE:[2:$1/$2@$0](hive/.*@REALM.TDP)s/.*/hive/
+      DEFAULT
+    </value>
+  </property>
+  <!-- Proxy User Settings -->
+  <property>
+    <name>hadoop.proxyuser.trino.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.trino.groups</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.hive.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.hive.groups</name>
+    <value>*</value>
+  </property>
+</configuration>
+```
+
+### hdfs-site.xml
+Configures HDFS High Availability (HA), NameNode RPC addresses, and Kerberos principals.
+
+```xml
+<configuration>
+  <property>
+    <name>dfs.nameservices</name>
+    <value>mycluster</value>
+  </property>
+  <property>
+    <name>dfs.ha.namenodes.mycluster</name>
+    <value>nn1,nn2</value>
+  </property>
+  <property>
+    <name>dfs.namenode.rpc-address.mycluster.nn1</name>
+    <value>master-01.tdp:8020</value>
+  </property>
+  <property>
+    <name>dfs.namenode.rpc-address.mycluster.nn2</name>
+    <value>master-02.tdp:8020</value>
+  </property>
+  <property>
+    <name>dfs.client.failover.proxy.provider.mycluster</name>
+    <value>org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider</value>
+  </property>
+  <property>
+    <name>dfs.namenode.kerberos.principal</name>
+    <value>nn/_HOST@REALM.TDP</value>
+  </property>
+  <property>
+    <name>dfs.datanode.kerberos.principal</name>
+    <value>dn/_HOST@REALM.TDP</value>
+  </property>
+  <property>
+    <name>dfs.data.transfer.protection</name>
+    <value>authentication</value>
+  </property>
+</configuration>
+```
+
+### hive-site.xml
+Configures the Hive Metastore connection and Thrift protocol.
+
+```xml
+<configuration>
+  <property>
+    <name>hive.zookeeper.quorum</name>
+    <value>master-01.tdp:2181,master-02.tdp:2181,master-03.tdp:2181</value>
+  </property>
+  <property>
+    <name>hive.metastore.sasl.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>metastore.kerberos.principal</name>
+    <value>hive/_HOST@REALM.TDP</value>
+  </property>
+  <property>
+    <name>metastore.thrift.uris</name>
+    <value>thrift://master-02.tdp:9083,thrift://master-03.tdp:9083</value>
+  </property>
+</configuration>
+```
+
+### krb5.conf
+Standard Kerberos configuration for the TDP realm.
+
+```ini
+[libdefaults]
+  default_realm = REALM.TDP
+  dns_lookup_realm = false
+  ticket_lifetime = 24h
+  renew_lifetime = 7d
+  forwardable = true
+
+[realms]
+  REALM.TDP = {
+    kdc = master-01.tdp
+    admin_server = master-01.tdp
+  }
+
+[domain_realm]
+  .tdp = REALM.TDP
+```

--- a/packages/okdp-packages/trinodb/README-TDP.md
+++ b/packages/okdp-packages/trinodb/README-TDP.md
@@ -4,6 +4,19 @@ This document outlines the steps to configure and deploy the necessary Kubernete
 
 ## Prerequisites
 
+Ensure the `trino` user exists in your TDP cluster and has the necessary proxy permissions. This is configured in the `core-site.xml` of your TDP cluster:
+
+```xml
+<property>
+  <name>hadoop.proxyuser.trino.hosts</name>
+  <value>*</value>
+</property>
+<property>
+  <name>hadoop.proxyuser.trino.groups</name>
+  <value>*</value>
+</property>
+```
+
 Ensure you have the following files available in your `../tdp-client` directory. **Note: Configuration files are auto-generated in the TDP environment.**
 
 - `trino.keytab`: Kerberos keytab for the Trino service principal.

--- a/packages/okdp-packages/trinodb/trinodb-tdp.yaml
+++ b/packages/okdp-packages/trinodb/trinodb-tdp.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1alpha1
+name: trinodb
+tag: 1.0.0-tdp
+protected: false
+description: |
+  Apache Trino - Distributed SQL query engine designed for large-scale data processing across multiple data sources.
+  High-performance, in-memory query engine that enables fast, interactive analytics on diverse data systems.
+  Supports querying data from multiple databases, data warehouses, and big data platforms in a single query.
+  This version integrates TDP with Hive and HDFS supporting Kerberos auth and impersonation.
+usage:
+  text: |
+    Apache Trino provides distributed SQL query engine designed for large-scale data processing.
+    Access the UI at https://{{ .Release.metadata.name }}.{{ .Context.ingress.suffix }}
+schema:
+  parameters:
+    properties:
+      numWorkers: { type: integer, default: 3, description: "Number of workers" }
+      tdp_ca_cert: { type: string, default: "tdp-ca-cert", description: "CA cert secret name" }
+      tdp_ca_cert_filename: { type: string, default: "tdp_ca.crt", description: "CA cert filename" }
+      trino_keytab: { type: string, default: "trino-keytab", description: "Trino keytab secret name" }
+      trino_keytab_filename: { type: string, default: "trino.keytab", description: "Trino keytab filename" }
+      hadoop_client_config: { type: string, default: "hadoop-client-config", description: "Hadoop client configmap name" }
+      hive_metastore_uri: { type: string, default: "thrift://master-02.tdp:9083,thrift://master-03.tdp:9083", description: "Hive metastore URI" }
+      hive_hdfs_trino_principal: { type: string, default: "trino@REALM.TDP", description: "Hive HDFS Trino principal" }
+      hive_metastore_service_principal: { type: string, default: "hive/_HOST@REALM.TDP", description: "Hive metastore service principal" }
+  context:
+    properties:
+      certificateIssuers:
+        required: true
+        properties:
+          selfSigned:
+            properties:
+              name: { type: string, required: true }
+      ingress:
+        required: true
+        properties:
+          suffix: { type: string, required: true }
+modules:
+  - name: main
+    timeout: 10m
+    source:
+      helmRepository:
+        url: https://trinodb.github.io/charts/
+        chart: trino
+        version: v1.39.1
+    values: |
+      coordinator:
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "2"
+            memory: "8Gi"
+        additionalVolumes:
+          - name: generated-files
+            emptyDir: {}
+          - name: cacerts
+            secret:
+              secretName: certs-bundle
+          - name: trino-tls
+            secret:
+              secretName: {{ .Release.metadata.name }}-tls
+          - name:  {{ .Parameters.tdp_ca_cert }}
+            secret:
+              secretName: {{ .Parameters.tdp_ca_cert }}
+              items:
+                - key: {{ .Parameters.tdp_ca_cert_filename }}
+                  path: {{ .Parameters.tdp_ca_cert_filename }}
+          - name: {{ .Parameters.trino_keytab }}
+            secret:
+              secretName: {{ .Parameters.trino_keytab }}
+              items:
+                - key: {{ .Parameters.trino_keytab_filename }}
+                  path: {{ .Parameters.trino_keytab_filename }}
+          - name: {{ .Parameters.hadoop_client_config }}
+            configMap:
+               name: {{ .Parameters.hadoop_client_config }}
+        additionalVolumeMounts:
+          - name: generated-files
+            mountPath: /etc/trino/generated
+            readOnly: false
+          - name: cacerts
+            mountPath: /cacerts
+          - name: trino-tls
+            mountPath: /trino-tls
+          - name: {{ .Parameters.trino_keytab }}
+            mountPath: /etc/trino/keytabs
+          - name: {{ .Parameters.tdp_ca_cert }}
+            mountPath: /tdp-ca-cert
+          - name: {{ .Parameters.hadoop_client_config }}
+            mountPath: /etc/trino/hadoop
+          - name: {{ .Parameters.hadoop_client_config }}
+            mountPath: /etc/krb5.conf    
+            subPath: krb5.conf  
+        additionalJVMConfig:
+          - "-Djavax.net.ssl.trustStore=/cacerts/bundle.p12"
+          - "-Djavax.net.ssl.trustStorePassword="
+
+
+      worker:
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "2"
+            memory: "2Gi"
+        additionalVolumes:
+          - name: generated-files
+            emptyDir: {}
+          - name: cacerts
+            secret:
+              secretName: certs-bundle
+          - name: trino-tls
+            secret:
+              secretName: {{ .Release.metadata.name }}-tls
+          - name:  {{ .Parameters.tdp_ca_cert }}
+            secret:
+              secretName: {{ .Parameters.tdp_ca_cert }}
+              items:
+                - key: {{ .Parameters.tdp_ca_cert_filename }}
+                  path: {{ .Parameters.tdp_ca_cert_filename }}
+          - name: {{ .Parameters.trino_keytab }}
+            secret:
+              secretName: {{ .Parameters.trino_keytab }}
+              items:
+                - key: {{ .Parameters.trino_keytab_filename }}
+                  path: {{ .Parameters.trino_keytab_filename }}
+          - name: {{ .Parameters.hadoop_client_config }}
+            configMap:
+               name: {{ .Parameters.hadoop_client_config }}
+        additionalVolumeMounts:
+          - name: generated-files
+            mountPath: /etc/trino/generated
+            readOnly: false
+          - name: cacerts
+            mountPath: /cacerts
+          - name: trino-tls
+            mountPath: /trino-tls
+          - name: {{ .Parameters.trino_keytab }}
+            mountPath: /etc/trino/keytabs
+          - name: {{ .Parameters.tdp_ca_cert }}
+            mountPath: /tdp-ca-cert
+          - name: {{ .Parameters.hadoop_client_config }}
+            mountPath: /etc/trino/hadoop
+          - name: {{ .Parameters.hadoop_client_config }}
+            mountPath: /etc/krb5.conf    
+            subPath: krb5.conf  
+        additionalJVMConfig:
+          - "-Djavax.net.ssl.trustStore=/cacerts/bundle.p12"
+          - "-Djavax.net.ssl.trustStorePassword="
+
+      ingress:
+        enabled: true
+        className: nginx
+        annotations:
+          cert-manager.io/cluster-issuer: "{{ .Context.certificateIssuers.selfSigned.name }}"
+          nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+          nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+          nginx.ingress.kubernetes.io/use-regex: "true"  
+          nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+          nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+          nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        hosts:
+          - host: {{ .Release.metadata.name }}.{{ .Context.ingress.suffix }}
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - hosts:
+              - {{ .Release.metadata.name }}.{{ .Context.ingress.suffix }}
+            secretName: {{ .Release.metadata.name }}-tls
+
+      server:
+        workers: {{ .Parameters.numWorkers }}
+        node:
+          environment: sandbox
+        config:
+          coordinator: "true"
+          node-scheduler.include-coordinator: "true"
+          discovery-server.enabled: "true"
+          path: /etc/trino
+          https:
+            enabled: true
+            port: 8443
+            keystore:
+              path: "/etc/trino/generated/tls.pem"
+        coordinatorExtraConfig: |
+          http-server.process-forwarded=true
+          web-ui.authentication.type=oauth2
+          http-server.authentication.oauth2.issuer=https://keycloak.{{ .Context.ingress.suffix }}/realms/master
+          http-server.authentication.oauth2.client-id=confidential-oidc-client
+          http-server.authentication.oauth2.client-secret=secret1
+          http-server.authentication.oauth2.auth-url=https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/auth
+          http-server.authentication.oauth2.token-url=https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/token
+          http-server.authentication.oauth2.scopes=openid,email,profile,groups
+          deprecated.http-server.authentication.oauth2.groups-field=groups
+
+
+      initContainers:
+        coordinator:
+          - name: init-coordinator-coordinator
+            image: openjdk:11-jre-slim
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - -c
+              - |
+                cat /trino-tls/tls.crt /trino-tls/tls.key > /etc/trino/generated/tls.pem
+                cp /cacerts/bundle.p12 /etc/trino/generated/
+                keytool -importcert -alias tdp-ca -file /tdp-ca-cert/{{ .Parameters.tdp_ca_cert_filename }} -keystore /etc/trino/generated/bundle.p12 -noprompt
+            volumeMounts:
+              - name: trino-tls
+                mountPath: "/trino-tls"
+              - name: cacerts
+                mountPath: /cacerts
+              - name: generated-files
+                readOnly: false
+                mountPath: "/etc/trino/generated"
+              - name: tdp-ca-cert
+                mountPath: /tdp-ca-cert
+        worker:
+          - name: init-coordinator-worker
+            image: openjdk:11-jre-slim
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - -c
+              - |
+                cat /trino-tls/tls.crt /trino-tls/tls.key > /etc/trino/generated/tls.pem
+                cp /cacerts/bundle.p12 /etc/trino/generated/
+                keytool -importcert -alias tdp-ca -file /tdp-ca-cert/{{ .Parameters.tdp_ca_cert_filename }} -keystore /etc/trino/generated/bundle.p12 -noprompt
+            volumeMounts:
+              - name: trino-tls
+                mountPath: "/trino-tls"
+              - name: cacerts
+                mountPath: /cacerts
+              - name: generated-files
+                readOnly: false
+                mountPath: "/etc/trino/generated"
+              - name: tdp-ca-cert
+                mountPath: /tdp-ca-cert
+      catalogs:
+        tdp_hive: |-
+          connector.name=hive
+          hive.metastore.uri={{ .Parameters.hive_metastore_uri }}
+          fs.hadoop.enabled=true
+          hive.config.resources=/etc/trino/hadoop/core-site.xml, /etc/trino/hadoop/hdfs-site.xml, /etc/trino/hadoop/hive-site.xml
+          hive.hdfs.impersonation.enabled=true
+          hive.hdfs.authentication.type=KERBEROS
+          hive.hdfs.trino.principal={{ .Parameters.hive_hdfs_trino_principal }}
+          hive.hdfs.trino.keytab=/etc/trino/keytabs/{{ .Parameters.trino_keytab_filename }}
+          hive.metastore.authentication.type=KERBEROS
+          hive.metastore.thrift.impersonation.enabled=true
+          hive.metastore.service.principal={{ .Parameters.hive_metastore_service_principal }}
+          hive.metastore.client.principal={{ .Parameters.hive_hdfs_trino_principal }}
+          hive.metastore.client.keytab=/etc/trino/keytabs/{{ .Parameters.trino_keytab_filename }}
+          hive.metastore.thrift.client.connect-timeout=1h
+          hive.metastore.thrift.client.read-timeout=1h
+
+
+roles:
+  - Interactive-query
+dependencies:
+  - ingress 

--- a/packages/okdp-packages/trinodb/trinodb-tdp.yaml
+++ b/packages/okdp-packages/trinodb/trinodb-tdp.yaml
@@ -15,13 +15,13 @@ schema:
   parameters:
     properties:
       numWorkers: { type: integer, default: 3, description: "Number of workers" }
-      tdp_ca_cert: { type: string, default: "tdp-ca-cert", description: "CA cert secret name" }
+      tdp_ca_cert_secret_name: { type: string, default: "tdp-ca-cert", description: "CA cert secret name" }
       tdp_ca_cert_filename: { type: string, default: "tdp_ca.crt", description: "CA cert filename" }
-      trino_keytab: { type: string, default: "trino-keytab", description: "Trino keytab secret name" }
+      trino_keytab_secret_name: { type: string, default: "trino-keytab", description: "Trino keytab secret name" }
       trino_keytab_filename: { type: string, default: "trino.keytab", description: "Trino keytab filename" }
-      hadoop_client_config: { type: string, default: "hadoop-client-config", description: "Hadoop client configmap name" }
+      hadoop_client_configmap_name: { type: string, default: "hadoop-client-config", description: "Hadoop client configmap name" }
       hive_metastore_uri: { type: string, default: "thrift://master-02.tdp:9083,thrift://master-03.tdp:9083", description: "Hive metastore URI" }
-      hive_hdfs_trino_principal: { type: string, default: "trino@REALM.TDP", description: "Hive HDFS Trino principal" }
+      trino_principal: { type: string, default: "trino@REALM.TDP", description: "Hive HDFS Trino principal" }
       hive_metastore_service_principal: { type: string, default: "hive/_HOST@REALM.TDP", description: "Hive metastore service principal" }
   context:
     properties:
@@ -61,21 +61,21 @@ modules:
           - name: trino-tls
             secret:
               secretName: {{ .Release.metadata.name }}-tls
-          - name:  {{ .Parameters.tdp_ca_cert }}
+          - name:  {{ .Parameters.tdp_ca_cert_secret_name }}
             secret:
-              secretName: {{ .Parameters.tdp_ca_cert }}
+              secretName: {{ .Parameters.tdp_ca_cert_secret_name }}
               items:
                 - key: {{ .Parameters.tdp_ca_cert_filename }}
                   path: {{ .Parameters.tdp_ca_cert_filename }}
-          - name: {{ .Parameters.trino_keytab }}
+          - name: {{ .Parameters.trino_keytab_secret_name }}
             secret:
-              secretName: {{ .Parameters.trino_keytab }}
+              secretName: {{ .Parameters.trino_keytab_secret_name }}
               items:
                 - key: {{ .Parameters.trino_keytab_filename }}
                   path: {{ .Parameters.trino_keytab_filename }}
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             configMap:
-               name: {{ .Parameters.hadoop_client_config }}
+               name: {{ .Parameters.hadoop_client_configmap_name }}
         additionalVolumeMounts:
           - name: generated-files
             mountPath: /etc/trino/generated
@@ -84,13 +84,13 @@ modules:
             mountPath: /cacerts
           - name: trino-tls
             mountPath: /trino-tls
-          - name: {{ .Parameters.trino_keytab }}
+          - name: {{ .Parameters.trino_keytab_secret_name }}
             mountPath: /etc/trino/keytabs
-          - name: {{ .Parameters.tdp_ca_cert }}
+          - name: {{ .Parameters.tdp_ca_cert_secret_name }}
             mountPath: /tdp-ca-cert
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             mountPath: /etc/trino/hadoop
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             mountPath: /etc/krb5.conf    
             subPath: krb5.conf  
         additionalJVMConfig:
@@ -115,21 +115,21 @@ modules:
           - name: trino-tls
             secret:
               secretName: {{ .Release.metadata.name }}-tls
-          - name:  {{ .Parameters.tdp_ca_cert }}
+          - name:  {{ .Parameters.tdp_ca_cert_secret_name }}
             secret:
-              secretName: {{ .Parameters.tdp_ca_cert }}
+              secretName: {{ .Parameters.tdp_ca_cert_secret_name }}
               items:
                 - key: {{ .Parameters.tdp_ca_cert_filename }}
                   path: {{ .Parameters.tdp_ca_cert_filename }}
-          - name: {{ .Parameters.trino_keytab }}
+          - name: {{ .Parameters.trino_keytab_secret_name }}
             secret:
-              secretName: {{ .Parameters.trino_keytab }}
+              secretName: {{ .Parameters.trino_keytab_secret_name }}
               items:
                 - key: {{ .Parameters.trino_keytab_filename }}
                   path: {{ .Parameters.trino_keytab_filename }}
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             configMap:
-               name: {{ .Parameters.hadoop_client_config }}
+               name: {{ .Parameters.hadoop_client_configmap_name }}
         additionalVolumeMounts:
           - name: generated-files
             mountPath: /etc/trino/generated
@@ -138,13 +138,13 @@ modules:
             mountPath: /cacerts
           - name: trino-tls
             mountPath: /trino-tls
-          - name: {{ .Parameters.trino_keytab }}
+          - name: {{ .Parameters.trino_keytab_secret_name }}
             mountPath: /etc/trino/keytabs
-          - name: {{ .Parameters.tdp_ca_cert }}
+          - name: {{ .Parameters.tdp_ca_cert_secret_name }}
             mountPath: /tdp-ca-cert
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             mountPath: /etc/trino/hadoop
-          - name: {{ .Parameters.hadoop_client_config }}
+          - name: {{ .Parameters.hadoop_client_configmap_name }}
             mountPath: /etc/krb5.conf    
             subPath: krb5.conf  
         additionalJVMConfig:
@@ -249,12 +249,12 @@ modules:
           hive.config.resources=/etc/trino/hadoop/core-site.xml, /etc/trino/hadoop/hdfs-site.xml, /etc/trino/hadoop/hive-site.xml
           hive.hdfs.impersonation.enabled=true
           hive.hdfs.authentication.type=KERBEROS
-          hive.hdfs.trino.principal={{ .Parameters.hive_hdfs_trino_principal }}
+          hive.hdfs.trino.principal={{ .Parameters.trino_principal }}
           hive.hdfs.trino.keytab=/etc/trino/keytabs/{{ .Parameters.trino_keytab_filename }}
           hive.metastore.authentication.type=KERBEROS
           hive.metastore.thrift.impersonation.enabled=true
           hive.metastore.service.principal={{ .Parameters.hive_metastore_service_principal }}
-          hive.metastore.client.principal={{ .Parameters.hive_hdfs_trino_principal }}
+          hive.metastore.client.principal={{ .Parameters.trino_principal }}
           hive.metastore.client.keytab=/etc/trino/keytabs/{{ .Parameters.trino_keytab_filename }}
           hive.metastore.thrift.client.connect-timeout=1h
           hive.metastore.thrift.client.read-timeout=1h

--- a/packages/okdp-packages/trinodb/trinodb-tdp.yaml
+++ b/packages/okdp-packages/trinodb/trinodb-tdp.yaml
@@ -177,6 +177,7 @@ modules:
         node:
           environment: sandbox
         config:
+          authenticationType: "oauth2"
           coordinator: "true"
           node-scheduler.include-coordinator: "true"
           discovery-server.enabled: "true"
@@ -189,12 +190,14 @@ modules:
         coordinatorExtraConfig: |
           http-server.process-forwarded=true
           web-ui.authentication.type=oauth2
+          http-server.authentication.type=oauth2
           http-server.authentication.oauth2.issuer=https://keycloak.{{ .Context.ingress.suffix }}/realms/master
           http-server.authentication.oauth2.client-id=confidential-oidc-client
           http-server.authentication.oauth2.client-secret=secret1
           http-server.authentication.oauth2.auth-url=https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/auth
           http-server.authentication.oauth2.token-url=https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/token
           http-server.authentication.oauth2.scopes=openid,email,profile,groups
+          http-server.authentication.oauth2.principal-field=preferred_username
           deprecated.http-server.authentication.oauth2.groups-field=groups
 
 
@@ -259,6 +262,8 @@ modules:
           hive.metastore.thrift.client.connect-timeout=1h
           hive.metastore.thrift.client.read-timeout=1h
 
+      additionalConfigProperties:
+        - internal-communication.shared-secret=random123
 
 roles:
   - Interactive-query


### PR DESCRIPTION
# Trino TDP Integration 

The steps to configure and deploy the necessary Kubernetes resources for integrating Trino with TDP, enabling support for Kerberos authentication, Hive, and HDFS query federation.

## Prerequisites

Ensure you have the following files available in your `../tdp-client` directory. **Note: Configuration files are auto-generated in the TDP environment.**

- `trino.keytab`: Kerberos keytab for the Trino service principal.
- `tdp_ca.crt`: The CA certificate for the TDP cluster.
- Hadoop configuration files (`core-site.xml`, `hdfs-site.xml`, `hive-site.xml`) and `krb5.conf`.

---

## 1. Secrets Management

Run the following commands to create the required Kubernetes secrets. These secrets store sensitive authentication materials.

### Create Trino Keytab Secret
```bash
kubectl create secret generic trino-keytab \
  --from-file=trino.keytab=../tdp-client/trino.keytab \
  --namespace=default
```

### Create CA Certificate Secret
```bash
kubectl create secret generic tdp-ca-cert \
  --from-file=tdp_ca.crt=../tdp-client/tdp_ca.crt \
  --namespace=default
```

**Verification:**
You can verify the secrets layout using `kubectl describe`:

```yaml
Name:         tdp-ca-cert
Namespace:    default
Type:         Opaque
Data:
  tdp_ca.crt: 1887 bytes

Name:         trino-keytab
Namespace:    default
Type:         Opaque
Data:
  trino.keytab: 433 bytes
```

---

## 2. Hadoop Client Configuration

The `hadoop-client-config` ConfigMap is essential for Trino to communicate with the HDFS and Hive Metastore services. It contains the standard Hadoop XML configuration files and the Kerberos configuration, which are **auto-generated** in the TDP client directory.

### Create ConfigMap
Navigate to the directory containing your configuration files (e.g., `../tdp-client/hadoop-client`) and run:

```bash
kubectl create configmap hadoop-client-config \
  --from-file=. \
  --namespace=default
```

---

## 3. Configuration Reference

Below are examples of the **auto-generated** configurations included in the `hadoop-client-config` ConfigMap. These are provided for reference.

### core-site.xml
Defines the default filesystem, Zookeeper quorum, and proxy user settings.

```xml
<configuration>
  <property>
    <name>fs.defaultFS</name>
    <value>hdfs://mycluster</value>
  </property>
  <property>
    <name>ha.zookeeper.quorum</name>
    <value>master-01.tdp:2181,master-02.tdp:2181,master-03.tdp:2181</value>
  </property>
  <property>
    <name>ha.zookeeper.acl</name>
    <value>sasl:nn:rwcda</value>
  </property>
  <property>
    <name>hadoop.security.authentication</name>
    <value>kerberos</value>
  </property>
  <property>
    <name>hadoop.security.authorization</name>
    <value>true</value>
  </property>
  <property>
    <name>hadoop.security.auth_to_local</name>
    <value>
      RULE:[2:$1/$2@$0]([ndj]n/.*@REALM.TDP)s/.*/hdfs/
      RULE:[1:$1@$0](hdfs@REALM.TDP)s/.*/hdfs/
      RULE:[2:$1/$2@$0](trino/.*@REALM.TDP)s/.*/trino/
      RULE:[2:$1/$2@$0](hive/.*@REALM.TDP)s/.*/hive/
      DEFAULT
    </value>
  </property>
  <!-- Proxy User Settings -->
  <property>
    <name>hadoop.proxyuser.trino.hosts</name>
    <value>*</value>
  </property>
  <property>
    <name>hadoop.proxyuser.trino.groups</name>
    <value>*</value>
  </property>
  <property>
    <name>hadoop.proxyuser.hive.hosts</name>
    <value>*</value>
  </property>
  <property>
    <name>hadoop.proxyuser.hive.groups</name>
    <value>*</value>
  </property>
</configuration>
```

### hdfs-site.xml
Configures HDFS High Availability (HA), NameNode RPC addresses, and Kerberos principals.

```xml
<configuration>
  <property>
    <name>dfs.nameservices</name>
    <value>mycluster</value>
  </property>
  <property>
    <name>dfs.ha.namenodes.mycluster</name>
    <value>nn1,nn2</value>
  </property>
  <property>
    <name>dfs.namenode.rpc-address.mycluster.nn1</name>
    <value>master-01.tdp:8020</value>
  </property>
  <property>
    <name>dfs.namenode.rpc-address.mycluster.nn2</name>
    <value>master-02.tdp:8020</value>
  </property>
  <property>
    <name>dfs.client.failover.proxy.provider.mycluster</name>
    <value>org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider</value>
  </property>
  <property>
    <name>dfs.namenode.kerberos.principal</name>
    <value>nn/_HOST@REALM.TDP</value>
  </property>
  <property>
    <name>dfs.datanode.kerberos.principal</name>
    <value>dn/_HOST@REALM.TDP</value>
  </property>
  <property>
    <name>dfs.data.transfer.protection</name>
    <value>authentication</value>
  </property>
</configuration>
```

### hive-site.xml
Configures the Hive Metastore connection and Thrift protocol.

```xml
<configuration>
  <property>
    <name>hive.zookeeper.quorum</name>
    <value>master-01.tdp:2181,master-02.tdp:2181,master-03.tdp:2181</value>
  </property>
  <property>
    <name>hive.metastore.sasl.enabled</name>
    <value>true</value>
  </property>
  <property>
    <name>metastore.kerberos.principal</name>
    <value>hive/_HOST@REALM.TDP</value>
  </property>
  <property>
    <name>metastore.thrift.uris</name>
    <value>thrift://master-02.tdp:9083,thrift://master-03.tdp:9083</value>
  </property>
</configuration>
```

### krb5.conf
Standard Kerberos configuration for the TDP realm.

```ini
[libdefaults]
  default_realm = REALM.TDP
  dns_lookup_realm = false
  ticket_lifetime = 24h
  renew_lifetime = 7d
  forwardable = true

[realms]
  REALM.TDP = {
    kdc = master-01.tdp
    admin_server = master-01.tdp
  }

[domain_realm]
  .tdp = REALM.TDP
```