### PR TITLE
`dnsmasq` permision denied issue

### DIFF
--- a/packages/system/dns-server/chart/templates/deployment.yaml
+++ b/packages/system/dns-server/chart/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --conf-file=/etc/dnsmasq/dnsmasq.conf
             - --keep-in-foreground
           ports:
             - name: dns-udp
@@ -35,7 +34,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/dnsmasq
+              mountPath: /etc/dnsmasq.conf
+              subPath: dnsmasq.conf
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
The following issue may appear on the `dns-server` pod during the initial installation:

> /etc/dnsmasq/dnsmasq.conf : permission denied

This PR tries to solve it by using the default `dnsmasq` config file: https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html#lbAF