### PR TITLE
fix(keycloak): align keycloak and okdp admin user

### DIFF
--- a/packages/system/keycloak/keycloak.yaml
+++ b/packages/system/keycloak/keycloak.yaml
@@ -30,11 +30,11 @@ schema:
     properties:
       adminUser:
         type: string
-        default: "admin"
+        default: "adm"
         description: "Keycloak admin username"
       adminPassword:
         type: string
-        default: "admin"
+        default: "adm"
         description: "Keycloak admin password"
 
 modules:


### PR DESCRIPTION
Fixes: #45  by setting keycloak `admin` to 'adm`. 