### PR TITLE
fix(airflow): pass context proxy env to dags gitSync container

### DIFF
--- a/packages/okdp-packages/airflow/airflow.yaml
+++ b/packages/okdp-packages/airflow/airflow.yaml
@@ -342,6 +342,21 @@ modules:
           {{- if .Parameters.dagGitCredentialsSecret }}
           credentialsSecret: {{ .Parameters.dagGitCredentialsSecret | quote }}
           {{- end }}
+          {{- if or .Context.proxy.httpProxy .Context.proxy.httpsProxy .Context.proxy.noProxy }}
+          env:
+            {{- if .Context.proxy.httpProxy }}
+            - name: HTTP_PROXY
+              value: {{ .Context.proxy.httpProxy | quote }}
+            {{- end }}
+            {{- if .Context.proxy.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Context.proxy.httpsProxy | quote }}
+            {{- end }}
+            {{- if .Context.proxy.noProxy }}
+            - name: NO_PROXY
+              value: {{ .Context.proxy.noProxy | quote }}
+            {{- end }}
+          {{- end }}
 
       flower:
         enabled: false


### PR DESCRIPTION
Inject HTTP_PROXY/HTTPS_PROXY/NO_PROXY from .Context.proxy into dags.gitSync.env so gitSync can clone DAG repos through a corporate proxy