### PR TITLE
fix(keycloak): grant admin realm role to adm user

### DIFF
--- a/clusters/sandbox/default-context.yaml
+++ b/clusters/sandbox/default-context.yaml
@@ -434,7 +434,7 @@ spec:
           firstName: adm
           lastName: adm
           password: adm
-          roles: [admins]
+          roles: [admins, admin]
       groups:
         - name: teama
         - name: teamb


### PR DESCRIPTION
Closes #45.

The `adm` user (defined in `clusters/sandbox/default-context.yaml`) is the OIDC admin used to log into OKDP UI, Airflow, JupyterHub, Superset, and the other user-facing services. It only carried the custom `admins` realm role, so it could not log into the Keycloak admin console — that one requires the master realm's native `admin` role. The bootstrap superuser `admin/admin` was the only way in, which conflicted with the `adm` OIDC session and produced the auth/session loop described in the issue.

Adding the native `admin` role to `adm` lets a single account drive both the user-facing services and Keycloak administration. The change is purely additive: existing services that map roles do so on the `admins` group (Superset's `AUTH_ROLES_MAPPING`, JupyterHub's `admin_groups`, etc.), not on the native `admin` role, so nothing else is affected.

Verified locally on the kind sandbox by granting the role via `kcadm.sh` and logging into both the Keycloak admin console and OKDP UI as `adm/adm` without any session conflict.