### PR TITLE
fix(ingress-nginx): disable allowSnippetAnnotations to mitigate CVE-2026-42945

### DIFF
--- a/packages/system/ingress-nginx/ingress-nginx.yaml
+++ b/packages/system/ingress-nginx/ingress-nginx.yaml
@@ -56,7 +56,7 @@ modules:
         version: 4.12.1
     values: |
       controller:
-        allowSnippetAnnotations: "true"
+        allowSnippetAnnotations: "false"
         extraArgs:
           enable-ssl-passthrough: true
         admissionWebhooks:


### PR DESCRIPTION
Sets `allowSnippetAnnotations: false `on the ingres-nginx controller as a quick mitigation for `CVE-2026-42945`

### Impact
All of the components never use `configuration-snippet` or `server-snippet` annotations. It is more pure security hardening with no regression.

The long term mitigation would be to upgrade the controller to >=1.30.1