### PR TITLE
fix(contexts): scope defaultStorage endpoints to the release name

### DIFF
--- a/clusters/sandbox/contexts/20-provider-context.yaml
+++ b/clusters/sandbox/contexts/20-provider-context.yaml
@@ -29,9 +29,9 @@ spec:
         name: RustFS
         region: dummy
         endpoints:
-          apiUrl: https://{{ .Release.metadata.name }}-api.{{ .Context.ingress.suffix }}
-          stsUrl: https://{{ .Release.metadata.name }}-api.{{ .Context.ingress.suffix }}
-          consoleUrl: https://{{ .Release.metadata.name }}.{{ .Context.ingress.suffix }}
+          apiUrl: https://storage-{{ .Release.namespace }}-api.{{ .Context.ingress.suffix }}
+          stsUrl: https://storage-{{ .Release.namespace }}-api.{{ .Context.ingress.suffix }}
+          consoleUrl: https://storage-{{ .Release.namespace }}.{{ .Context.ingress.suffix }}
 
     # -- OIDC identity provider contract. The sandbox binds it to Keycloak, but any OIDC provider exposing these endpoints can be plugged in.
     defaultIdp:

--- a/clusters/sandbox/contexts/20-provider-context.yaml
+++ b/clusters/sandbox/contexts/20-provider-context.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   # -- Provider interface bindings used by service contexts. Replace these with external providers that satisfy the same contracts.
   context:
-    # -- Object storage provider contract. The sandbox binds it to RustFS using S3-compatible API, STS, and console endpoints.
+    # -- Object storage provider contract. The sandbox binds it to storage using S3-compatible API, STS, and console endpoints.
     defaultStorage:
       provider:
         type: s3

--- a/clusters/sandbox/contexts/20-provider-context.yaml
+++ b/clusters/sandbox/contexts/20-provider-context.yaml
@@ -26,7 +26,7 @@ spec:
     defaultStorage:
       provider:
         type: s3
-        name: RustFS
+        name: storage
         region: dummy
         endpoints:
           apiUrl: https://storage-{{ .Release.namespace }}-api.{{ .Context.ingress.suffix }}

--- a/clusters/sandbox/contexts/20-provider-context.yaml
+++ b/clusters/sandbox/contexts/20-provider-context.yaml
@@ -22,16 +22,16 @@ metadata:
 spec:
   # -- Provider interface bindings used by service contexts. Replace these with external providers that satisfy the same contracts.
   context:
-    # -- Object storage provider contract. The sandbox binds it to SeaweedFS using S3-compatible API, STS, and console endpoints.
+    # -- Object storage provider contract. The sandbox binds it to RustFS using S3-compatible API, STS, and console endpoints.
     defaultStorage:
       provider:
         type: s3
-        name: SeaweedFS
+        name: RustFS
         region: dummy
         endpoints:
-          apiUrl: https://seaweedfs-{{ .Release.namespace }}.{{ .Context.ingress.suffix }}
-          stsUrl: https://seaweedfs-{{ .Release.namespace }}.{{ .Context.ingress.suffix }}
-          consoleUrl: https://seaweedfs-console-{{ .Release.namespace }}.{{ .Context.ingress.suffix }}
+          apiUrl: https://{{ .Release.metadata.name }}-api.{{ .Context.ingress.suffix }}
+          stsUrl: https://{{ .Release.metadata.name }}-api.{{ .Context.ingress.suffix }}
+          consoleUrl: https://{{ .Release.metadata.name }}.{{ .Context.ingress.suffix }}
 
     # -- OIDC identity provider contract. The sandbox binds it to Keycloak, but any OIDC provider exposing these endpoints can be plugged in.
     defaultIdp:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

The defaultStorage provider context still hardcoded seaweedfs- hostnames, a leftover from before the storage backend became pluggable (e.g: rustfs). This broke the console's Open button: the server only publishes a URL when an Ingress host exactly matches <release>.<suffix>, but the actual hosts were seaweedfs-<namespace>.<suffix>.

Scope apiUrl/stsUrl/consoleUrl to {{ .Release.metadata.name }} instead, which the rustfs package already knows how to substitute.

## Related Issue

Fixes #67 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

<!-- Steps a reviewer can follow to manually verify this change -->
<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [x] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.