### PR TITLE
fix(contexts): replace SeaweedFS-specific storage with neutral storage settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It provides a ready-to-use data platform environment covering identity, object s
 The default OKDP sandbox deploys a complete local data-platform environment with:
 
 - Keycloak for identity and access management
-- SeaweedFS for object storage
+- SeaweedFS (or an alternative S3-compatible backend, e.g. RustFS) for object storage
 - Spark Operator and Spark History Server for Spark workloads and monitoring
 - Apache Airflow for workflow orchestration
 - JupyterHub for interactive data-science workspaces
@@ -360,7 +360,7 @@ kubectl get secret default-issuer -n cert-manager -o jsonpath='{.data.ca\.crt}' 
 
 **Option 2**: Ignore certificate warnings
 - **First, connect to Keycloak** (https://keycloak.okdp.sandbox or https://keycloak.<CUSTOM_DOMAIN>) and accept the self-signed certificate in your browser.
-- This step is **mandatory** for all OKDP services (UI, Seaweedfs, etc.) to communicate properly with Keycloak.
+- This step is **mandatory** for all OKDP services (UI, object storage, etc.) to communicate properly with Keycloak.
 
 ## Quick Start Guide
 

--- a/clusters/sandbox/contexts/30-service-context.yaml
+++ b/clusters/sandbox/contexts/30-service-context.yaml
@@ -211,7 +211,7 @@ spec:
         provider: defaultStorage
         # The access key is used for STS interactions between Polaris and S3 (sts:AssumeRole)
         # + catalog-side Iceberg metadata ops
-        # The Polaris SeaweedFS identity for STS
+        # This is the Polaris identity the storage backend registers for STS
         credentialsSecret:
           name: creds-polaris-s3
           accessKeyKey: accessKey

--- a/clusters/sandbox/contexts/99-examples-context.yaml
+++ b/clusters/sandbox/contexts/99-examples-context.yaml
@@ -418,7 +418,7 @@ spec:
                 "\n",
                 "You’ll be able to explore:\n",
                 "\n",
-                "- **[SeaweedFS](https://github.com/seaweedfs/seaweedfs)** for S3-compatible object storage\n",
+                "- **S3-compatible object storage** for the lakehouse data\n",
                 "- **[Hive Metastore](https://hive.apache.org/)** for table/catalog metadata\n",
                 "- **[Trino](https://trino.io/)** for interactive SQL queries\n",
                 "- **[Jupyter](https://jupyter.org/)** for notebooks and analysis\n",
@@ -438,7 +438,7 @@ spec:
                 "\n",
                 "## 🧭 What’s inside the repo\n",
                 "\n",
-                "- **Helm-driven workflows** to download public datasets and upload them to S3 (SeaweedFS)\n",
+                "- **Helm-driven workflows** to download public datasets and upload them to S3\n",
                 "- **Trino SQL** examples to create external tables and sync partitions\n",
                 "- **Jupyter notebooks** to query Trino (SQLAlchemy + native SQL)\n",
                 "- Optional **Superset** workflows for visualization\n",
@@ -888,9 +888,6 @@ spec:
               - "https://polaris-console-default.{{ .Context.ingress.suffix }}/auth/callback"
             webOrigins:
               - "https://polaris-console-default.{{ .Context.ingress.suffix }}"
-          - clientId: seaweedfs-s3
-            name: seaweedfs-s3
-            publicClient: true
           - clientId: superset
             name: superset
             secret: mySupersetSecret
@@ -1146,10 +1143,6 @@ spec:
             owner:
               username: "keycloak"
               passwordSecret: creds-keycloak-db
-          - name: seaweedfs
-            owner:
-              username: "seaweedfs"
-              passwordSecret: creds-seaweedfs-db
           - name: polaris
             owner:
               username: "polaris"

--- a/clusters/sandbox/contexts/99-examples-context.yaml
+++ b/clusters/sandbox/contexts/99-examples-context.yaml
@@ -733,6 +733,9 @@ spec:
           anonymousRead: true
         - name: hive
         - name: spark-events
+          # Spark's FsHistoryProvider fails to even start if its configured log directory
+          # doesn't already exist — S3 has no real directories, so this must be pre-seeded.
+          paths: [ event-logs ]
       grants:
         - principal: hiveMetastore
           actions: [ read, write, list ]

--- a/clusters/sandbox/contexts/99-examples-context.yaml
+++ b/clusters/sandbox/contexts/99-examples-context.yaml
@@ -717,64 +717,66 @@ spec:
                   - service_admin
                   - catalog_admin
 
-    # -- Sandbox-specific storage provider implementation settings for SeaweedFS databases, S3 credentials, STS, and identities.
+    # -- Backend-agnostic object storage provisioning: buckets to create and per-consumer
+    # grants, expressed against the neutral defaultStorage contract so any
+    # backend package (RustFS, SeaweedFS, ...) can provision them the same way. Each
+    # grant's credentialsSecret is the consumer's own pre-existing S3 secret (e.g.
+    # creds-trino-s3): the storage backend registers those same access/secret key values
+    # as a valid identity, it does not mint new credentials.
     defaultStorage:
-      # Sandbox implementation-specific
-      # Consider this part already provided by your platform
-      # settings: {}
-      settings:
-        filer:
-          database:
-            provider: defaultDatabaseServer
-            name: seaweedfs
-            credentialsSecret:
-              name: creds-seaweedfs-db
-              usernameKey: username
-              passwordKey: password
-        s3:
-          enabled: true
-          s3_secret: creds-seaweedfs-identities
-          bucketAnonymousRead: true
+      buckets:
+        - name: bronze
+          anonymousRead: true
+        - name: silver
+          anonymousRead: true
+        - name: gold
+          anonymousRead: true
+        - name: hive
+        - name: spark-events
+      grants:
+        - principal: hiveMetastore
+          actions: [ read, write, list ]
+          buckets: [ hive ]
           credentialsSecret:
-            name: creds-seaweedfs-s3
+            name: creds-hive-metastore-s3
             accessKeyKey: accessKey
             secretKeyKey: secretKey
-
-          sts:
-            enabled: true
-            roleArn: arn:aws:iam::000000000000:role/S3WriteRole
-
-          advanced:
-            identities:
-              hiveMetastore:
-                identity: hiveMetastore
-                actions: [ Read, Write, List ]
-              trino:
-                identity: trino
-                actions: [ Read, Write, List, Admin ]
-              jupyterHub:
-                identity: jupyterHub
-                actions: [ Read, Write, List ]
-              sparkHistory:
-                identity: sparkHistory
-                actions: [ Read, Write, List ]
-              # SeaweedFS matches the accessKey above in the SigV4 request to the configured S3 credentials
-              # under this identity. The identity name can be anything and has importance for debugging issues
-              # SeaweedFS expects an admin identity to authorize it for sts:AssumeRole.
-              # response: code=AccessDenied, type=Sender, message=user
-              # polaris is not authorized to assume role arn:aws:iam::000000000000:role/S3WriteRole
-              polaris:
-                identity: polaris
-                actions: [ Read, Write, List, Admin ]
-              airflow:
-                identity: airflow
-                actions: [ Read, Write, List, Admin ]
-              examples:
-                identity: examples
-                actions: [ Admin, Read, Write, List ]
-              seaweedfs:
-                identity: seaweedfs
-                actions: [ Admin ]
+        - principal: trino
+          actions: [ read, write, list, admin ]
+          credentialsSecret:
+            name: creds-trino-s3
+            accessKeyKey: S3_ACCESS_KEY
+            secretKeyKey: S3_SECRET_ACCESS
+        - principal: jupyterHub
+          actions: [ read, write, list ]
+          buckets: [ bronze, silver, gold ]
+          credentialsSecret:
+            name: creds-jupyterhub-s3
+            accessKeyKey: S3_ACCESS_KEY
+            secretKeyKey: S3_SECRET_KEY
+        - principal: sparkHistory
+          actions: [ read, write, list ]
+          buckets: [ spark-events ]
+          credentialsSecret:
+            name: creds-spark-history-s3
+            accessKeyKey: accessKey
+            secretKeyKey: secretKey
+        # Polaris assumes a role to vend temporary S3 credentials for Iceberg tables
+        # (STS), hence sts: true instead of a bucket-scoped action list.
+        - principal: polaris
+          sts: true
+          credentialsSecret:
+            name: creds-polaris-s3
+            accessKeyKey: accessKey
+            secretKeyKey: secretKey
+        # Shared by the "examples" data-loading workflows and the JupyterHub lakehouse
+        # PySpark connection, which both reference this same secret.
+        - principal: examples
+          actions: [ read, write, list, admin ]
+          credentialsSecret:
+            name: creds-examples-s3
+            accessKeyKey: S3_ACCESS_KEY
+            secretKeyKey: S3_SECRET_KEY
 
     # -- Sandbox-specific identity provider settings for Keycloak users, roles, clients, service accounts, and OIDC scopes.
     defaultIdp:

--- a/clusters/sandbox/releases/local-secrets-provider.yaml
+++ b/clusters/sandbox/releases/local-secrets-provider.yaml
@@ -27,6 +27,6 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/platform-packages-v0.3/local-secrets-provider
-    tag: 1.0.0-p03
+    tag: 1.0.0-p04
     timeout: 10m
   targetNamespace: default


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description
The sandbox example configuration was still using a SeaweedFS-specific storage configuration instead of the neutral `defaultStorage` contract.

As a result, storage providers implementing the `defaultStorage` contract (such as RustFS) did not receive any bucket or grant definitions during provisioning. No buckets were created and no S3 identities were registered, even though platform services (Trino, JupyterHub, Hive Metastore, Spark History Server, Polaris, ...) were already configured to use the project's default storage.

This PR replaces the backend-specific configuration with the neutral `defaultStorage.buckets` and `defaultStorage.grants` schema.

The existing `credentialsSecret` of each consumer is reused without modification. During provisioning, the storage backend creates the required buckets and registers the corresponding S3 identities, allowing all storage consumers to authenticate using their existing credentials.


## Related Issue

Fixes #69 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

1. Apply this context and force-reconcile the storage release's HelmRelease.
2. Check the provisioning Job's logs:
  ` kubectl logs -n <project> -l job-name=<release>-provision`
   Expect: bronze/silver/gold/hive/spark-events created, and 6 users added with policies attached
   (hiveMetastore, trino, jupyterHub, sparkHistory, polaris, examples).
3. Verify an existing consumer secret now authenticates, e.g.:
```
   mc alias set rf https://storage-<namespace>.<suffix> <creds-trino-s3 access key> <secret key>
   mc ls rf/bronze
```

Verified locally on the sandbox: all of the above passed, Trino's existing creds-trino-s3 credentials authenticate against RustFS successfully.


## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [x] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.