### PR TITLE
docs(readme): document metrics-server install for the Kind sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,6 @@ flux install
 
 #### Install metrics-server
 
-> ℹ️ **Note**  
-> This step is only required for a fresh installation.
-
-> ℹ️ Kind clusters don't ship [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
-> by default. Without it, the Kubernetes Metrics API has nothing to report, and the OKDP console
-> shows CPU/Memory usage as unavailable for every service
->
-> The `--kubelet-insecure-tls` patch is required because Kind's kubelet serving certificates
-> aren't signed by a CA metrics-server trusts by default.
-
 ```sh
 kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 kubectl patch deployment metrics-server -n kube-system --type=json \

--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ kind create cluster --config "$env:TEMP\okdp-sandbox-config.yaml"
 flux install
 ```
 
+#### Install metrics-server
+
+> ℹ️ **Note**  
+> This step is only required for a fresh installation.
+
+> ℹ️ Kind clusters don't ship [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
+> by default. Without it, the Kubernetes Metrics API has nothing to report, and the OKDP console
+> shows CPU/Memory usage as unavailable for every service
+>
+> The `--kubelet-insecure-tls` patch is required because Kind's kubelet serving certificates
+> aren't signed by a CA metrics-server trusts by default.
+
+```sh
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+kubectl patch deployment metrics-server -n kube-system --type=json \
+  -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kubelet-insecure-tls"}]'
+```
+
+Verify it's working:
+
+```sh
+kubectl top nodes
+```
+
 #### Configure proxy settings for Flux controllers (Optional)
 
 If your environment requires a proxy to reach external sources (container registries), the following command sets the proxy configuration variables to all Flux controllers (source, kustomize, helm, notification):


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

## Description

Kind clusters do not include `metrics-server` by default, and the sandbox Quick Start didn't install it either.

As a result, a fresh sandbox deployment has no Kubernetes Metrics API available. The control plane gracefully reports metrics as unavailable, which causes the OKDP console to display `CPU` and `Memory` as unavailable for every service.

This PR updates the Quick Start documentation to include the installation of `metrics-server` after the Flux bootstrap.

Since Kind's kubelet serving certificates are not trusted by `metrics-server` out of the box, the documented installation also applies the required `--kubelet-insecure-tls` patch.

Once installed, `kubectl top` works as expected and the console displays CPU and memory usage for deployed services.

## Related Issue

Fixes #71 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

1. Create a fresh Kind cluster (or use one where `metrics-server` is not installed).
2. Follow the new **Install metrics-server** section from the README.
3. Wait for the deployment to become ready:

   ```sh
   kubectl rollout status deployment metrics-server -n kube-system
   ```

4. Verify that the Kubernetes Metrics API is working:

   ```sh
   kubectl top nodes
   kubectl top pods -n <project>
   ```

   Both commands should return CPU and memory usage instead of `error: Metrics API not available`.

5. Open the OKDP console and verify that:
   - the **Platform Dashboard** displays CPU and memory usage
   - the **Service Details** page displays CPU and memory usage for deployed services

<img width="5098" height="2565" alt="image" src="https://github.com/user-attachments/assets/6aed7179-d1cb-40c0-8cad-4157c3a206b3" />

### Verification

Verified locally on a fresh Kind cluster.

<!-- Steps a reviewer can follow to manually verify this change -->
<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [x] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.