### PR TITLE
fix: point at current platform-packages registry without version prefix

### DIFF
--- a/clusters/sandbox/contexts/10-platform-context.yaml
+++ b/clusters/sandbox/contexts/10-platform-context.yaml
@@ -44,7 +44,7 @@ spec:
         oidc:
           enabled: true
           provider: defaultIdp
-        packageRepository: quay.io/okdp/platform-packages-v0.3
+        packageRepository: quay.io/okdp/platform-packages
         clusters:
           - id: sandbox
             name: "OKDP Sandbox Cluster"

--- a/clusters/sandbox/releases/cert-manager.yaml
+++ b/clusters/sandbox/releases/cert-manager.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "Certificate management for Kubernetes with trust-manager and issuers"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/cert-manager
+    repository: quay.io/okdp/platform-packages/cert-manager
     tag: 1.17.1-p06
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/cloudnative-pg.yaml
+++ b/clusters/sandbox/releases/cloudnative-pg.yaml
@@ -26,7 +26,7 @@ spec:
     clusters in Kubernetes environments.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/cloudnative-pg
+    repository: quay.io/okdp/platform-packages/cloudnative-pg
     tag: 1.29.1-p01
     timeout: 10m
   targetNamespace: cnpg-system

--- a/clusters/sandbox/releases/cnpg-postgresql.yaml
+++ b/clusters/sandbox/releases/cnpg-postgresql.yaml
@@ -26,7 +26,7 @@ spec:
     instance (cluster) and includes ownership, access credentials, and lifecycle management through Kubernetes-native CRDs.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/cnpg-postgresql
+    repository: quay.io/okdp/platform-packages/cnpg-postgresql
     tag: 18.3-p01
     timeout: 10m
   targetNamespace: cnpg-system

--- a/clusters/sandbox/releases/coredns-patch.yaml
+++ b/clusters/sandbox/releases/coredns-patch.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "CoreDNS configuration patch for local domain resolution"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/coredns-patch
+    repository: quay.io/okdp/platform-packages/coredns-patch
     tag: 1.0.0-p04
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/dns-server.yaml
+++ b/clusters/sandbox/releases/dns-server.yaml
@@ -24,7 +24,7 @@ spec:
   description: DNS Server - Lightweight DNS server for local development
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/dns-server
+    repository: quay.io/okdp/platform-packages/dns-server
     tag: 1.0.0-p03
     timeout: 10m
   targetNamespace: dns-server

--- a/clusters/sandbox/releases/ingress-nginx.yaml
+++ b/clusters/sandbox/releases/ingress-nginx.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "NGINX Ingress Controller for HTTP/HTTPS routing"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/ingress-nginx
+    repository: quay.io/okdp/platform-packages/ingress-nginx
     tag: 4.12.1-p03
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/keycloak.yaml
+++ b/clusters/sandbox/releases/keycloak.yaml
@@ -24,7 +24,7 @@ spec:
   description: Keycloak identity and access management
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/keycloak
+    repository: quay.io/okdp/platform-packages/keycloak
     tag: 24.4.11-p07
     timeout: 10m
   parameters:

--- a/clusters/sandbox/releases/local-secrets-provider.yaml
+++ b/clusters/sandbox/releases/local-secrets-provider.yaml
@@ -26,7 +26,7 @@ spec:
     secrets, services, and environment variables across multiple platform components.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/local-secrets-provider
+    repository: quay.io/okdp/platform-packages/local-secrets-provider
     tag: 1.0.0-p03
     timeout: 10m
   targetNamespace: default

--- a/clusters/sandbox/releases/okdp-server.yaml
+++ b/clusters/sandbox/releases/okdp-server.yaml
@@ -24,7 +24,7 @@ spec:
   description: OKDP Server - API backend for the Open Kubernetes Data Platform
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/okdp-server
+    repository: quay.io/okdp/platform-packages/okdp-server
     tag: 0.4.0-p01
     timeout: 10m
   targetNamespace: okdp-server

--- a/clusters/sandbox/releases/okdp-ui.yaml
+++ b/clusters/sandbox/releases/okdp-ui.yaml
@@ -24,7 +24,7 @@ spec:
   description: OKDP UI - Frontend web interface for the Open Kubernetes Data Platform
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages-v0.3/okdp-ui
+    repository: quay.io/okdp/platform-packages/okdp-ui
     tag: 0.4.1-p02
     timeout: 10m
   targetNamespace: okdp-ui

--- a/clusters/sandbox/releases/spark-operator.yaml
+++ b/clusters/sandbox/releases/spark-operator.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: "Spark Operator for managing Apache Spark applications on Kubernetes"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/spark-operator
+    repository: quay.io/okdp/platform-packages/spark-operator
     tag: 2.4.0-p02
   parameters:
     jobNamespaces: [""] # Allow all namespaces for sandbox simplicity

--- a/clusters/sandbox/releases/spark-rbac.yaml
+++ b/clusters/sandbox/releases/spark-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: "Spark ServiceAccount and RBAC for Spark applications"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/spark-rbac
+    repository: quay.io/okdp/platform-packages/spark-rbac
     tag: 1.0.1-p01
   targetNamespace: default
   createNamespace: false

--- a/clusters/sandbox/releases/tools.yaml
+++ b/clusters/sandbox/releases/tools.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "Miscellaneous Kubernetes tools for cluster management"
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/tools
+    repository: quay.io/okdp/platform-packages/tools
     tag: 1.0.0-p01
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/webhooks.yaml
+++ b/clusters/sandbox/releases/webhooks.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: Second stage of kubocd installation
   package:
-    repository: quay.io/okdp/platform-packages-v0.3/kubocd-webhooks
+    repository: quay.io/okdp/platform-packages/kubocd-webhooks
     tag: v0.2.1-p01
     interval: 30m
     timeout: 10m


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

Updates all references from the stale `quay.io/okdp/platform-packages-v0.3` to the current publish target `quay.io/okdp/platform-packages`

## Related Issue

Fixes #73 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

<!-- Steps a reviewer can follow to manually verify this change -->
<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [ ] Documentation updated if needed
- [ ] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.