### PR TITLE
fix: point sandbox-dependencies owned releases to the corresponding OCI path

### DIFF
--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -20,13 +20,15 @@
 # then applies the contexts and releases from clusters/sandbox/ exactly as the
 # README instructs and waits until every KuboCD Release reaches READY.
 #
-# Unlike the package CI in OKDP/platform-packages, this workflow builds nothing:
-# it deploys the already-published packages (quay.io/okdp/platform-packages/<pkg>)
-# straight from the manifests, so it validates the deployment layer, not packages.
+# Unlike the package CI in OKDP/platform-packages and OKDP/sandbox-dependencies,
+# this workflow builds nothing: it deploys the already-published packages straight from
+# the manifests, so it validates the deployment layer, not the packages themselves.
 #
-# NOTE: the releases reference quay.io/okdp/platform-packages/<pkg> (no version
-# suffix), which only exists once OKDP/platform-packages#19 has merged and
-# republished. Until then this workflow is expected to fail.
+# Packages come from two registries, matching repository ownership:
+# - quay.io/okdp/sandbox-dependencies/<pkg>: third-party and bootstrap dependencies the sandbox needs but OKDP does not own.
+# - quay.io/okdp/platform-packages/<pkg>: OKDP core services and control plane.
+# Each release pins its own full path and tag; clusters/sandbox/releases/ is the
+# source of truth for which package comes from where.
 
 name: Deploy validation (sandbox e2e)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository owns the **single-cluster sandbox deployment**. It describes how
 - `clusters/sandbox/contexts/` : the layered KuboCD `Context` files (`10-platform`, `20-provider`, `30-service`, `99-examples`)
 - `docs/` : deployment guides (DNS, certificates)
 
-The **packages themselves** (the KuboCD packages bundled as OCI artifacts) live in a dedicated repository and are consumed here from the registry. This repository never builds packages, it only deploys published ones.
+The **packages themselves** (the KuboCD packages bundled as OCI artifacts) live in dedicated repositories, split by ownership, OKDP core versus the third-party dependencies OKDP does not own and are consumed here from the registry. This repository never builds packages, it only deploys published ones.
 
 | Concern | Owner |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ The **packages themselves** (the KuboCD packages bundled as OCI artifacts) live 
 
 | Concern | Owner |
 |---|---|
-| KuboCD packages (system and services), build and release automation | [`OKDP/platform-packages`](https://github.com/OKDP/platform-packages) |
+| KuboCD packages for core services and control plane | [`OKDP/platform-packages`](https://github.com/OKDP/platform-packages) |
+| KuboCD packages for third-party and bootstrap dependencies | [`OKDP/sandbox-dependencies`](https://github.com/OKDP/sandbox-dependencies) |
 | Reusable utility Helm charts | [`OKDP/helm-charts-utilities`](https://github.com/OKDP/helm-charts-utilities) |
 | Notebooks, DAGs, and runnable examples | [`OKDP/okdp-examples`](https://github.com/OKDP/okdp-examples) |
 | OKDP web UI | [`OKDP/okdp-ui`](https://github.com/OKDP/okdp-ui) |

--- a/clusters/sandbox/releases/cert-manager.yaml
+++ b/clusters/sandbox/releases/cert-manager.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "Certificate management for Kubernetes with trust-manager and issuers"
   package:
-    repository: quay.io/okdp/platform-packages/cert-manager
+    repository: quay.io/okdp/sandbox-dependencies/cert-manager
     tag: 1.17.1-p06
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/cloudnative-pg.yaml
+++ b/clusters/sandbox/releases/cloudnative-pg.yaml
@@ -26,7 +26,7 @@ spec:
     clusters in Kubernetes environments.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages/cloudnative-pg
+    repository: quay.io/okdp/sandbox-dependencies/cloudnative-pg
     tag: 1.29.1-p01
     timeout: 10m
   targetNamespace: cnpg-system

--- a/clusters/sandbox/releases/cnpg-postgresql.yaml
+++ b/clusters/sandbox/releases/cnpg-postgresql.yaml
@@ -26,7 +26,7 @@ spec:
     instance (cluster) and includes ownership, access credentials, and lifecycle management through Kubernetes-native CRDs.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages/cnpg-postgresql
+    repository: quay.io/okdp/sandbox-dependencies/cnpg-postgresql
     tag: 18.3-p01
     timeout: 10m
   targetNamespace: cnpg-system

--- a/clusters/sandbox/releases/coredns-patch.yaml
+++ b/clusters/sandbox/releases/coredns-patch.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "CoreDNS configuration patch for local domain resolution"
   package:
-    repository: quay.io/okdp/platform-packages/coredns-patch
+    repository: quay.io/okdp/sandbox-dependencies/coredns-patch
     tag: 1.0.0-p04
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/dns-server.yaml
+++ b/clusters/sandbox/releases/dns-server.yaml
@@ -24,7 +24,7 @@ spec:
   description: DNS Server - Lightweight DNS server for local development
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages/dns-server
+    repository: quay.io/okdp/sandbox-dependencies/dns-server
     tag: 1.0.0-p03
     timeout: 10m
   targetNamespace: dns-server

--- a/clusters/sandbox/releases/ingress-nginx.yaml
+++ b/clusters/sandbox/releases/ingress-nginx.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "NGINX Ingress Controller for HTTP/HTTPS routing"
   package:
-    repository: quay.io/okdp/platform-packages/ingress-nginx
+    repository: quay.io/okdp/sandbox-dependencies/ingress-nginx
     tag: 4.12.1-p03
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/keycloak.yaml
+++ b/clusters/sandbox/releases/keycloak.yaml
@@ -24,7 +24,7 @@ spec:
   description: Keycloak identity and access management
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages/keycloak
+    repository: quay.io/okdp/sandbox-dependencies/keycloak
     tag: 24.4.11-p07
     timeout: 10m
   parameters:

--- a/clusters/sandbox/releases/keycloak.yaml
+++ b/clusters/sandbox/releases/keycloak.yaml
@@ -25,7 +25,7 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/sandbox-dependencies/keycloak
-    tag: 24.4.11-p07
+    tag: 24.4.11-p09
     timeout: 10m
   parameters:
     adminPassword: admin

--- a/clusters/sandbox/releases/local-secrets-provider.yaml
+++ b/clusters/sandbox/releases/local-secrets-provider.yaml
@@ -27,6 +27,6 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/sandbox-dependencies/local-secrets-provider
-    tag: 1.0.0-p03
+    tag: 1.0.0-p04
     timeout: 10m
   targetNamespace: default

--- a/clusters/sandbox/releases/local-secrets-provider.yaml
+++ b/clusters/sandbox/releases/local-secrets-provider.yaml
@@ -26,7 +26,7 @@ spec:
     secrets, services, and environment variables across multiple platform components.
   package:
     interval: 30m
-    repository: quay.io/okdp/platform-packages/local-secrets-provider
+    repository: quay.io/okdp/sandbox-dependencies/local-secrets-provider
     tag: 1.0.0-p03
     timeout: 10m
   targetNamespace: default

--- a/clusters/sandbox/releases/tools.yaml
+++ b/clusters/sandbox/releases/tools.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: "Miscellaneous Kubernetes tools for cluster management"
   package:
-    repository: quay.io/okdp/platform-packages/tools
+    repository: quay.io/okdp/sandbox-dependencies/tools
     tag: 1.0.0-p01
     interval: 30m
     timeout: 10m

--- a/clusters/sandbox/releases/webhooks.yaml
+++ b/clusters/sandbox/releases/webhooks.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   description: Second stage of kubocd installation
   package:
-    repository: quay.io/okdp/platform-packages/kubocd-webhooks
+    repository: quay.io/okdp/sandbox-dependencies/kubocd-webhooks
     tag: v0.2.1-p01
     interval: 30m
     timeout: 10m


### PR DESCRIPTION


<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

Currently all releases point to `platform-packages` but some of them are now owned by `sandbox-dependencies`. This change fix the correct OCI path for `sandbox-dependencies` owned packages

## Related Issue

Fixes #78 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

<!-- Steps a reviewer can follow to manually verify this change -->
<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [ ] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.