### PR TITLE
fix(keycloak): add keycloak context variables for the dcr setting

### DIFF
--- a/clusters/sandbox/contexts/20-provider-context.yaml
+++ b/clusters/sandbox/contexts/20-provider-context.yaml
@@ -45,6 +45,7 @@ spec:
           tokenUrl: "https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/token"
           userinfoUrl: "https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/userinfo"
           jwksUri: "https://keycloak.{{ .Context.ingress.suffix }}/realms/master/protocol/openid-connect/certs"
+          clientRegistrationUrl: "https://keycloak.{{ .Context.ingress.suffix }}/realms/master/clients-registrations/openid-connect"
 
     # -- Database server provider contract for services that need PostgreSQL-compatible databases.
     defaultDatabaseServer:

--- a/clusters/sandbox/contexts/99-examples-context.yaml
+++ b/clusters/sandbox/contexts/99-examples-context.yaml
@@ -1125,6 +1125,12 @@ spec:
                   lightweight.claim: "true"
                   multivalued: "true"
                   userinfo.token.claim: "true"
+        anonymousDCR:
+          trustedHosts:
+            - "*.{{ .Context.ingress.suffix }}"
+            - "*.svc.cluster.local"    
+          allowedScopes:
+            - "groups"
 
     # Provision the following databases and configure the provider part.
     # -- Sandbox-specific database provisioning for service databases and owners.

--- a/clusters/sandbox/releases/keycloak.yaml
+++ b/clusters/sandbox/releases/keycloak.yaml
@@ -25,7 +25,7 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/sandbox-dependencies/keycloak
-    tag: 24.4.11-p09
+    tag: 24.4.11-p10
     timeout: 10m
   parameters:
     adminPassword: admin


### PR DESCRIPTION
## Description

Change keycloak registry target for the release and add various Keycloak variables related to the DCR protocol to the `99-examples-context.yaml` file

## Related Issue

Fixes OKDP/sandbox-dependencies#11

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

## How to Test

Make sure new registry is public. (quay.io/okdp/sandbox-dependencies/keycloak)
When you deploy keycloak from the sandbox, you can change the trustedHost and allowedScopes in the context file and check whether the changes took effect when keycloak was redeployed.

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [ ] Documentation updated if needed
- [ ] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.