### PR TITLE
Integrated Cilium as new CNI for sandbox cluster with kube-proxy replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The **packages themselves** (the KuboCD packages bundled as OCI artifacts) live 
 - [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [Flux CLI v2.7.5](https://fluxcd.io/flux/installation/)
+- [Cilium CLI](https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli)
+- [Helm](https://helm.sh/docs/intro/install/) 
 
 ## Quick start
 
@@ -81,6 +83,9 @@ cat > /tmp/okdp-sandbox-config.yaml <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: okdp-sandbox
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: "none"
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -107,6 +112,9 @@ kind create cluster --config /tmp/okdp-sandbox-config.yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: okdp-sandbox
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: "none"
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -125,8 +133,35 @@ kind create cluster --config "$env:TEMP\okdp-sandbox-config.yaml"
 
 </details>
 
+### 3. Install Cilium (CNI)
 
-### 3. Install Platform Components
+Until Cilium is installed, the cluster has no Pod networking. `kubectl get nodes` reports `NotReady` and this is expected. Installing Cilium brings networking into the cluster.
+
+Make sure to install Cilium before Flux as they need networking to start.
+Cilium also replaces **kube-proxy** for service exposure.
+
+To install Cilium:
+
+```sh
+# Cilium needs the API server address because kube-proxy is disabled.
+CLUSTER=okdp-sandbox # result of "kind get clusters" command
+NODE=$(kind get nodes --name "$CLUSTER" | grep -m1 control-plane)
+CP_IP=$(docker inspect "$NODE" -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+echo "control-plane IP: $CP_IP" # must be non-empty before you continue
+
+helm repo add cilium https://helm.cilium.io/ --force-update
+helm repo update cilium
+helm upgrade --install cilium cilium/cilium --version 1.19.6 \
+  --namespace kube-system \
+  -f clusters/sandbox/cilium/values.yaml \
+  --set k8sServiceHost="$CP_IP" --set k8sServicePort=6443
+
+# Wait for the datapath to come up
+kubectl -n kube-system rollout status ds/cilium --timeout=180s
+
+```
+
+### 4. Install Platform Components
 #### Install Flux (GitOps engine)
 
 > ℹ️ **Note**  
@@ -338,7 +373,7 @@ kubectl get releases -A --watch
 # Alternative: kubectl wait --for=condition=ready release --all --all-namespaces --timeout=600s
 ```
 
-### 4. DNS Setup
+### 5. DNS Setup
 
 Enable access to OKDP services through DNS resolution for the `okdp.sandbox` or your custom domain `<CUSTOM_DOMAIN>`:
 
@@ -348,7 +383,7 @@ Enable access to OKDP services through DNS resolution for the `okdp.sandbox` or 
 
 📋 **See [dns-configuration.md](docs/dns-configuration.md) for detailed setup instructions for your operating system.**
 
-### 5. SSL Certificate
+### 6. SSL Certificate
 
 For HTTPS access without warnings, two options:
 

--- a/clusters/sandbox/cilium/values.yaml
+++ b/clusters/sandbox/cilium/values.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Cilium replaces kube-proxy. Required by Cilium Ingress/Gateway (https://docs.cilium.io/en/stable/network/servicemesh/ingress/#prerequisites)
+kubeProxyReplacement: true
+
+# Envoy-based L7 datapath. Default to true. Ingress/Gateway depend on it.
+l7Proxy: true
+
+# Ingress/Gateway API: OFF for time being.
+# nginx (ingress-nginx) continues to serve all Ingress objects.
+ingressController:
+  enabled: false
+gatewayAPI:
+  enabled: false
+
+# Observability: Used to validate the datapath
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+  ui:
+    enabled: true
+
+# Kind single-node sizing/defaults
+operator:
+  # Single control-plane node. One operator replicas (default is 2 and would stay Pending)
+  replicas: 1

--- a/clusters/sandbox/cilium/values.yaml
+++ b/clusters/sandbox/cilium/values.yaml
@@ -34,6 +34,13 @@ hubble:
     enabled: true
   ui:
     enabled: true
+    frontend:
+      server:
+        ipv6:
+          # The sandbox is IPv4-only. The default chart value is set to true
+          # frontend bind [::]:8081 and CrashLoopBackOff on hots without an
+          # IPv6 stack in the pod netns
+          enabled: false
 
 # Kind single-node sizing/defaults
 operator:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

Introduced Cilium as the cluster CNI, replacing kindnet, with kube-proxy-replacement enabled. This is the prerequisites for migrating off the retired ingress-nginx to Gateway API.

## Related Issue

Fixes #84 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [x] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

<!-- Steps a reviewer can follow to manually verify this change -->
<!-- TODO: replace CONTRIBUTING.md feature branch link to main once merged -->

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [x] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.