### PR TITLE
chore(local-secrets-provider): bump to 1.0.0-p05

### DIFF
--- a/clusters/sandbox/releases/local-secrets-provider.yaml
+++ b/clusters/sandbox/releases/local-secrets-provider.yaml
@@ -27,6 +27,6 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/sandbox-dependencies/local-secrets-provider
-    tag: 1.0.0-p04
+    tag: 1.0.0-p05
     timeout: 10m
   targetNamespace: default


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits: feat: / fix: / docs: / chore: / refactor: …
For unfinished work, open as a Draft PR.
-->

## Description

Bumps the `local-secrets-provider` release to `1.0.0-p05`, which restores the `creds-seaweedfs-db` secret and unblocks `cnpg-postgresql` on a fresh install.
## Related Issue

Fixes #87 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Breaking change

<!-- If breaking change, describe the impact and migration path here: -->

## How to Test

1. Delete the existing releases and secrets, then reapply `clusters/sandbox/releases/` as described
   in the issue.
2. `cnpg-postgresql-main` installs instead of failing on the missing owner password Secret:

```bash
kubectl get helmreleases.helm.toolkit.fluxcd.io cnpg-postgresql-main -n kubocd-system -o json | jq '.status.conditions'
kubectl get secret creds-seaweedfs-db -n cnpg-system
```

## Checklist

<!-- - [ ] I have read [CONTRIBUTING.md](https://github.com/OKDP/.github/blob/main/CONTRIBUTING.md) -->
- [x] I have tested my changes
- [x] Documentation updated if needed
- [x] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
- [x] I hereby agree to grant [TOSIT](https://www.tosit.io/) a copyright license to use my contributions.