### PR TITLE
chore(packages): move to polaris p09, airflow p09 and the Control Plane 0.8.0

### DIFF
--- a/clusters/sandbox/contexts/platform-context.yaml
+++ b/clusters/sandbox/contexts/platform-context.yaml
@@ -71,7 +71,7 @@ spec:
           icon: pi-database
           services:
             - { name: hive-metastore, versions: ["4.0.1-p02"], default: "4.0.1-p02", description: Hive metastore }
-            - { name: polaris, versions: ["1.3.0-incubating-p07"], default: "1.3.0-incubating-p07", description: Apache Polaris Iceberg catalog }
+            - { name: polaris, versions: ["1.3.0-incubating-p09"], default: "1.3.0-incubating-p09", description: Apache Polaris Iceberg catalog }
         - title: Interactive Query
           icon: pi-bolt
           services:

--- a/clusters/sandbox/contexts/platform-context.yaml
+++ b/clusters/sandbox/contexts/platform-context.yaml
@@ -87,7 +87,7 @@ spec:
         - title: Data Engineering
           icon: pi-cog
           services:
-            - { name: airflow, versions: ["3.2.1-p07"], default: "3.2.1-p07", description: Apache Airflow }
+            - { name: airflow, versions: ["3.2.1-p09"], default: "3.2.1-p09", description: Apache Airflow }
         - title: Spark
           icon: pi-bolt
           services:

--- a/clusters/sandbox/project-demo/10-secrets.yaml
+++ b/clusters/sandbox/project-demo/10-secrets.yaml
@@ -140,11 +140,7 @@ spec:
         data:
           client_id: "polaris"
           client_secret: "myPolarisSecret"
-      # Realm 'sandbox' (index 0) bootstrap and OIDC admin principal
-      - name: creds-polaris-root-okdp-sandbox
-        data:
-          client_id: "polaris1"
-          client_secret: "thisIsSecret1"
+      # Realm 'sandbox' OIDC admin principal
       - name: creds-polaris-oauth2-admin-okdp-sandbox
         data:
           client_id: "svc-polaris-api-admin"

--- a/clusters/sandbox/project-demo/50-services.yaml
+++ b/clusters/sandbox/project-demo/50-services.yaml
@@ -53,31 +53,19 @@ spec:
   description: Polaris Iceberg catalog of the demo project
   package:
     repository: quay.io/okdp/platform-packages/polaris
-    tag: 1.3.0-incubating-p07
+    tag: 1.3.0-incubating-p09
     interval: 30m
     timeout: 10m
   parameters:
     db: demo-db-polaris
     storage: demo-storage
     s3SecretRef: creds-polaris-s3
-    realms:
-      - name: sandbox
-        rootPrincipal:
-          name: root
-          credentialsSecret:
-            name: creds-polaris-root-okdp-sandbox
-            clientIdKey: client_id
-            clientSecretKey: client_secret
-        # Polaris principal used through the management API: Polaris does not
-        # authenticate Keycloak clients, it keeps its own principals.
-        principals:
-          - name: service-account-svc-polaris-api-admin
-            clientId: svc-polaris-api-admin
-            credentialsSecret:
-              name: creds-polaris-oauth2-admin-okdp-sandbox
-              clientIdKey: client_id
-              clientSecretKey: client_secret
-            roles: [service_admin, catalog_admin]
+    realm: sandbox
+    # Polaris principal used through the management API: Polaris does not
+    # authenticate Keycloak clients, it keeps its own principals.
+    principals:
+      - name: service-account-svc-polaris-api-admin
+        roles: [service_admin, catalog_admin]
   targetNamespace: demo
 ---
 apiVersion: kubocd.kubotal.io/v1alpha1
@@ -112,17 +100,17 @@ spec:
         catalog: kcd-demo-polaris-catalog
         storage: demo-storage
         warehouse: demo
-        oidcSecretRef: creds-polaris-root-okdp-sandbox
+        oidcSecretRef: creds-demo-polaris-root
       - name: silver
         catalog: kcd-demo-polaris-catalog
         storage: demo-storage
         warehouse: silver
-        oidcSecretRef: creds-polaris-root-okdp-sandbox
+        oidcSecretRef: creds-demo-polaris-root
       - name: gold
         catalog: kcd-demo-polaris-catalog
         storage: demo-storage
         warehouse: gold
-        oidcSecretRef: creds-polaris-root-okdp-sandbox
+        oidcSecretRef: creds-demo-polaris-root
     # Fine-grained authorization is its own subject: the reference OPA policy
     # only knows named users, which the sandbox does not provision.
     enableOPA: false

--- a/clusters/sandbox/project-demo/50-services.yaml
+++ b/clusters/sandbox/project-demo/50-services.yaml
@@ -163,7 +163,7 @@ spec:
   description: Airflow of the demo project
   package:
     repository: quay.io/okdp/platform-packages/airflow
-    tag: 3.2.1-p07
+    tag: 3.2.1-p09
     interval: 30m
     timeout: 10m
   parameters:

--- a/clusters/sandbox/project-demo/60-polaris-catalog-job.yaml
+++ b/clusters/sandbox/project-demo/60-polaris-catalog-job.yaml
@@ -35,9 +35,9 @@ spec:
           image: curlimages/curl:latest
           env:
             - name: RCID
-              valueFrom: { secretKeyRef: { name: creds-polaris-root-okdp-sandbox, key: client_id } }
+              valueFrom: { secretKeyRef: { name: creds-demo-polaris-root, key: client_id } }
             - name: RCS
-              valueFrom: { secretKeyRef: { name: creds-polaris-root-okdp-sandbox, key: client_secret } }
+              valueFrom: { secretKeyRef: { name: creds-demo-polaris-root, key: client_secret } }
             - name: AK
               valueFrom: { secretKeyRef: { name: creds-seaweedfs-s3, key: accessKey } }
             - name: SK

--- a/clusters/sandbox/releases/okdp-control-plane-server.yaml
+++ b/clusters/sandbox/releases/okdp-control-plane-server.yaml
@@ -25,6 +25,6 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/platform-packages/okdp-control-plane-server
-    tag: 0.7.1-p02
+    tag: 0.8.0-p01
     timeout: 10m
   targetNamespace: okdp-system

--- a/clusters/sandbox/releases/okdp-control-plane-ui.yaml
+++ b/clusters/sandbox/releases/okdp-control-plane-ui.yaml
@@ -25,7 +25,7 @@ spec:
   package:
     interval: 30m
     repository: quay.io/okdp/platform-packages/okdp-control-plane-ui
-    tag: 0.7.0-p01
+    tag: 0.8.0-p01
     timeout: 10m
   parameters:
     oidcAuthority: https://keycloak.{{ .Context.ingress.suffix }}/realms/master


### PR DESCRIPTION
## Description

Repin the demo project on the packages published today: polaris `1.3.0-incubating-p09` (one realm and a root Secret generated by the package, so the demo declares `realm: sandbox` and its admin principal, and the Trino catalogs and the catalog Job read `creds-demo-polaris-root`), airflow `3.2.1-p09`, Control Plane packages `0.8.0-p01`, and the matching defaults of the platform Context.

Merge once these packages are on quay. On a cluster already installed, copy the former root Secret before applying:

```
kubectl -n demo get secret creds-polaris-root-okdp-sandbox -o json | python3 -c 'import json,sys; s=json.load(sys.stdin); print(json.dumps({"apiVersion":"v1","kind":"Secret","type":s["type"],"metadata":{"name":"creds-demo-polaris-root","namespace":"demo"},"data":s["data"]}))' | kubectl apply -f -
```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / chore
- [ ] Breaking change

## How to Test

1. deploy-validation is green once the packages are published.
2. Fresh install: the demo project comes up READY, Polaris included, with its console reachable.

## Checklist

- [ ] I have tested my changes
- [x] Documentation updated if needed
- [ ] If breaking change: migration path described above
- [x] I hereby declare this contribution to be licensed under the Apache License Version 2.0.
- [x] I hereby agree to grant TOSIT a copyright license to use my contributions.